### PR TITLE
修复IOS下取Property时发生的的jit问题

### DIFF
--- a/tolua/Assets/uLua/Core/Metatables.cs
+++ b/tolua/Assets/uLua/Core/Metatables.cs
@@ -352,7 +352,7 @@ namespace LuaInterface
 					if (cachedMember == null) setMemberCache(memberCache, objType, methodName, member);
 					try
 					{
-						object val = property.GetValue(obj, null);
+						object val = property.GetGetMethod().Invoke(obj, null);
 						
 						translator.push(luaState, val);
 					}


### PR DESCRIPTION
Attempting to JIT compile method
'System.Reflection.MonoProperty:GetterAdapterFrame
